### PR TITLE
Fix an issue with blocking mixed content

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
     </div>
   </div>
 
-  <script src="http://code.jquery.com/jquery-3.3.1.min.js"
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js"
 	   integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
 		 crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.20.1/math.min.js"></script>


### PR DESCRIPTION
Since github pages are served from https, then the stuff that is brought in (jquery in this case) needs to use the same protocol.